### PR TITLE
[Feature] Add custom texture

### DIFF
--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -89,6 +89,9 @@ L["Option.UnitReactionType.enable.Desc"] = "Enables/disables the indicator for t
 L["Option.UnitReactionType.texture.Name"] = "Texture"
 L["Option.UnitReactionType.texture.Desc"] = "The texture to use for the indicator"
 
+L["Option.UnitReactionType.textureCustom.Desc"] = "The custom texture path to use for the indicator"
+L["Option.UnitReactionType.textureCustom.Name"] = "Custom Texture"
+
 L["Option.UnitReactionType.width.Name"] = "Texture Width"
 L["Option.UnitReactionType.width.Desc"] = "The width of the texture"
 

--- a/core.lua
+++ b/core.lua
@@ -140,8 +140,12 @@ function Indicator:Update(nameplate)
 	self.enabled = unitConfig.enable;
 
 	if nameplate and config.enable then
+		local texture = config.texture
+		if texture == "custom" then
+			texture = config.textureCustom
+		end
 		self.Texture:Show()
-		self.Texture:SetTexture(config.texture)
+		self.Texture:SetTexture(texture)
 		self.Texture:SetSize(config.width, config.height)
 		self.Texture:SetAlpha(config.opacity)
 		self.Texture:SetPoint(config.texturePoint, nameplate, config.anchorPoint, config.xOffset, config.yOffset)

--- a/options.lua
+++ b/options.lua
@@ -44,7 +44,9 @@ local TEXTURE_NAMES = {
 }
 
 -- Add the directory prefix to the texture names and localise the descriptions
-local TEXTURES = {}
+local TEXTURES = {
+	custom = "Custom"
+}
 do
 	for _, textureName in ipairs(TEXTURE_NAMES) do
 		local description = L[("Dropdown.Texture.%s.Desc"):format(textureName)]
@@ -195,6 +197,17 @@ local function CreateUnitRectionTypeConfigTable(unit, unitReactionType, order)
 				values = TEXTURES,
 				style = "dropdown",
 			},
+			textureCustom = {
+				name = getName,
+				desc = getDesc,
+				order = nextIndex(),
+				width = "full",
+				type = "input",
+				hidden = function(info)
+					local unitConfig, _ = findProfileTableAndKey(info)
+					return unitConfig.texture ~= "custom"
+				end,
+			},
 			textureDisplay = {
 				name = "",
 				width = "full",
@@ -202,6 +215,9 @@ local function CreateUnitRectionTypeConfigTable(unit, unitReactionType, order)
 				type = "description",
 				image = function(info)
 					local unitConfig, _ = findProfileTableAndKey(info)
+					if unitConfig.texture == "custom" then
+						return unitConfig.textureCustom
+					end
 					return unitConfig.texture
 				end,
 				imageWidth = 100,


### PR DESCRIPTION
## What happened

- Add custom texture from a path
 
## Insight

- Besides available textures, now we can add a custom texture by place a texture file into `Interface` folder or using Blizzard Interface
Ex: `Interface\\CURSOR\\Attack`
<img width="605" alt="Screen Shot 2021-10-02 at 16 19 00" src="https://user-images.githubusercontent.com/17875522/135710527-a7cce00e-40ad-440d-a086-4e73c5e92f84.png">

## Proof Of Work

Config
<img width="656" alt="Screen Shot 2021-10-02 at 16 14 07" src="https://user-images.githubusercontent.com/17875522/135710547-08d21721-3baa-49f2-a105-88424fa2504e.png">

Result
<img width="144" alt="Screen Shot 2021-10-02 at 16 20 00" src="https://user-images.githubusercontent.com/17875522/135710546-5fec6e0f-2edf-414d-ba77-a91a82fbd33c.png">




